### PR TITLE
Support python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ other *.go, for example "pydatetime.go"
 ```
 
 
-Currently py package library use pkg-config to link "Python.h". User needs to set up pkg-config and "python-2.7.pc".
+Currently py package library use pkg-config to link "Python.h". User needs to set up pkg-config and "python-2.7.pc" (or python-3.x.pc).
 
 ## Example to set up pkg-config (with pyenv)
 
@@ -45,6 +45,17 @@ When python is installed as static object (*.so),  error will be occurred on bui
 ```bash
 env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install -v <version>
 ```
+
+## Use python3
+
+This py plugin supports Python2.7 on default. If build py plugin under Python3.x, build modules using `--tags` option, like:
+
+```sh
+build_sensorbee --only-generate-source=true
+go build --tags=py3.5 -o sensorbee sensorbee_main.go
+```
+
+Currently py package supports "py3.4", "py3.5" and "py3.6" tags. This support option using build constraints is beta version and it is possible to change in future.
 
 # Default UDS/UDF
 
@@ -230,6 +241,5 @@ sample_module.sample_module_method(arg1, arg2)
 
 # Attention
 
-* sensorbee/py supports only python2.x, not support 3.x
 * on windows OS, user need to customize cgo code to link between go and python.
 * To reload updated modules, need to re-run SensorBee. Python modules are imported when SensorBee setup to run, and cannot reload modifies python modules in SensorBee running.

--- a/_test_go2py.py
+++ b/_test_go2py.py
@@ -5,6 +5,10 @@ def go2py_tostr(arg):
     return str(arg)
 
 
+def go2py_toutf8(arg):
+    return arg.decode('utf-8')
+
+
 def go2py_mapinmap(arg):
     ret = arg['string']
     ret += '_' + arg['map']['instr']

--- a/_test_new_instance.py
+++ b/_test_new_instance.py
@@ -47,11 +47,11 @@ class PythonTest3():
         ins = PythonTest3()
         ins.a = a
         ins.b = b
-        ins.c = c
+        ins.c1 = c['v1']
         return ins
 
     def confirm(self):
-        return str(self.a) + '_' + str(self.b) + '_' + str(self.c)
+        return str(self.a) + '_' + str(self.b) + '_' + str(self.c1)
 
 
 class ChildClass(PythonTest3):
@@ -64,7 +64,10 @@ class PythonTestForKwd(object):
     def __init__(self, a, b=5, **c):
         self.a = a
         self.b = b
-        self.c = c
+        self.c = c['c'] if 'c' in c else ''
+        self.d = c['d'] if 'd' in c else ''
+        self.e = c['e'] if 'e' in c else ''
 
     def confirm_init(self):
-        return str(self.a) + '_' + str(self.b) + '_' + str(self.c)
+        return str(self.a) + '_' + str(self.b) + '_' + str(self.c) + '_' + \
+            str(self.d) + '_' + str(self.e)

--- a/_test_py2go.py
+++ b/_test_py2go.py
@@ -27,7 +27,7 @@ def return_unicode():
 
 
 def return_bytearray():
-    return bytearray('abcdefg')
+    return bytearray(b'abcdefg')
 
 
 def return_array():

--- a/cgolinks.go
+++ b/cgolinks.go
@@ -1,6 +1,6 @@
 package py
 
 /*
-#cgo pkg-config: python-2.7
+#cgo pkg-config: python-3.5
 */
 import "C"

--- a/cgolinks.go
+++ b/cgolinks.go
@@ -1,6 +1,10 @@
+// +build !py3.4
+// +build !py3.5
+// +build !py3.6
+
 package py
 
 /*
-#cgo pkg-config: python-3.5
+#cgo pkg-config: python-2.7
 */
 import "C"

--- a/cgolinks_py3.4.go
+++ b/cgolinks_py3.4.go
@@ -1,0 +1,8 @@
+// +build py3.4
+
+package py
+
+/*
+#cgo pkg-config: python-3.4
+*/
+import "C"

--- a/cgolinks_py3.5.go
+++ b/cgolinks_py3.5.go
@@ -1,0 +1,8 @@
+// +build py3.5
+
+package py
+
+/*
+#cgo pkg-config: python-3.5
+*/
+import "C"

--- a/cgolinks_py3.6.go
+++ b/cgolinks_py3.6.go
@@ -1,0 +1,8 @@
+// +build py3.6
+
+package py
+
+/*
+#cgo pkg-config: python-3.6
+*/
+import "C"

--- a/error.go
+++ b/error.go
@@ -2,61 +2,15 @@ package py
 
 /*
 #include "Python.h"
-
-PyObject* idOrNone(PyObject* o)
-{
-  return o ? o : Py_BuildValue("");
-}
-
-void fetchPythonError(PyObject* excInfo)
-{
-  PyObject *type, *value, *traceback;
-
-  PyErr_Fetch(&type, &value, &traceback);
-  PyErr_NormalizeException(&type, &value, &traceback);
-  if (traceback != NULL) {
-    PyException_SetTraceback(value, traceback);
-  }
-  PyTuple_SetItem(excInfo, 0, idOrNone(type));
-  PyTuple_SetItem(excInfo, 1, idOrNone(value));
-  PyTuple_SetItem(excInfo, 2, idOrNone(traceback));
-}
 */
 import "C"
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/sensorbee/py.v0/mainthread"
 	"strings"
 	"unicode"
 	"unsafe"
 )
-
-func init() {
-	ch := make(chan error)
-	mainthread.Exec(func() {
-		traceback, err := loadModule("traceback")
-		if err != nil {
-			ch <- err
-			return
-		}
-		defer traceback.decRef()
-		formatException, err := getPyFunc(traceback.p, "format_exception")
-		if err != nil {
-			ch <- err
-			return
-		}
-		tracebackFormatExceptionFunc = formatException
-
-		syntaxErrorType.p = C.PyExc_SyntaxError
-
-		ch <- nil
-	})
-
-	if err := <-ch; err != nil {
-		panic(err)
-	}
-}
 
 func loadModule(name string) (mod ObjectModule, err error) {
 	cName := C.CString(name)
@@ -111,7 +65,7 @@ func getPyErr() error {
 		return getPyErr()
 	}
 	defer excInfo.decRef()
-	C.fetchPythonError(excInfo.p)
+	fetchPythonError(excInfo)
 
 	formatted, err := tracebackFormatException(excInfo)
 	if err != nil {
@@ -139,11 +93,6 @@ func getPyErr() error {
 		syntaxErrMsg: syntaxErr,
 		stackTrace:   stackTrace,
 	}
-}
-
-func extractLineFromFormattedErrorMessage(formatted Object, n C.Py_ssize_t) string {
-	line := C.PyList_GetItem(formatted.p, n)
-	return C.GoString(C.PyUnicode_AsUTF8(line))
 }
 
 // pyErr represents an exception of python.

--- a/error_py2.go
+++ b/error_py2.go
@@ -1,0 +1,78 @@
+// +build !py3.4
+// +build !py3.5
+// +build !py3.6
+
+package py
+
+/*
+#include "Python.h"
+
+PyObject* idOrNone(PyObject* o)
+{
+  return o ? o : Py_BuildValue("");
+}
+
+void fetchPythonError(PyObject* excInfo)
+{
+  PyObject *type, *value, *traceback;
+  PyErr_Fetch(&type, &value, &traceback);
+  PyTuple_SetItem(excInfo, 0, idOrNone(type));
+  PyTuple_SetItem(excInfo, 1, idOrNone(value));
+  PyTuple_SetItem(excInfo, 2, idOrNone(traceback));
+}
+*/
+import "C"
+import (
+	"errors"
+	"unsafe"
+
+	"gopkg.in/sensorbee/py.v0/mainthread"
+)
+
+func init() {
+	ch := make(chan error)
+	mainthread.Exec(func() {
+		traceback, err := loadModule("traceback")
+		if err != nil {
+			ch <- err
+			return
+		}
+		defer traceback.decRef()
+		formatException, err := getPyFunc(traceback.p, "format_exception")
+		if err != nil {
+			ch <- err
+			return
+		}
+		tracebackFormatExceptionFunc = formatException
+
+		exceptions, err := loadModule("exceptions")
+		if err != nil {
+			ch <- err
+			return
+		}
+		defer exceptions.decRef()
+		syntaxErrorCString := C.CString("SyntaxError")
+		defer C.free(unsafe.Pointer(syntaxErrorCString))
+		syntaxError := C.PyObject_GetAttrString(exceptions.p, syntaxErrorCString)
+		if syntaxError == nil {
+			ch <- errors.New("cannot load exceptions.SyntaxError")
+			return
+		}
+		syntaxErrorType.p = syntaxError
+
+		ch <- nil
+	})
+
+	if err := <-ch; err != nil {
+		panic(err)
+	}
+}
+
+func fetchPythonError(o Object) {
+	C.fetchPythonError(o.p)
+}
+
+func extractLineFromFormattedErrorMessage(formatted Object, n C.Py_ssize_t) string {
+	line := C.PyList_GetItem(formatted.p, n)
+	return C.GoString(C.PyString_AsString(line))
+}

--- a/error_py2_test.go
+++ b/error_py2_test.go
@@ -1,0 +1,9 @@
+// +build !py3.4
+// +build !py3.5
+// +build !py3.6
+
+package py
+
+func loadExceptionModule() (ObjectModule, error) {
+	return LoadModule("exceptions")
+}

--- a/error_py3.go
+++ b/error_py3.go
@@ -1,0 +1,65 @@
+// +build py3.4 py3.5 py3.6
+
+package py
+
+/*
+#include "Python.h"
+
+PyObject* idOrNone(PyObject* o)
+{
+  return o ? o : Py_BuildValue("");
+}
+
+void fetchPythonError(PyObject* excInfo)
+{
+  PyObject *type, *value, *traceback;
+
+  PyErr_Fetch(&type, &value, &traceback);
+  PyErr_NormalizeException(&type, &value, &traceback);
+  if (traceback != NULL) {
+    PyException_SetTraceback(value, traceback);
+  }
+  PyTuple_SetItem(excInfo, 0, idOrNone(type));
+  PyTuple_SetItem(excInfo, 1, idOrNone(value));
+  PyTuple_SetItem(excInfo, 2, idOrNone(traceback));
+}
+*/
+import "C"
+import (
+	"gopkg.in/sensorbee/py.v0/mainthread"
+)
+
+func init() {
+	ch := make(chan error)
+	mainthread.Exec(func() {
+		traceback, err := loadModule("traceback")
+		if err != nil {
+			ch <- err
+			return
+		}
+		defer traceback.decRef()
+		formatException, err := getPyFunc(traceback.p, "format_exception")
+		if err != nil {
+			ch <- err
+			return
+		}
+		tracebackFormatExceptionFunc = formatException
+
+		syntaxErrorType.p = C.PyExc_SyntaxError
+
+		ch <- nil
+	})
+
+	if err := <-ch; err != nil {
+		panic(err)
+	}
+}
+
+func fetchPythonError(o Object) {
+	C.fetchPythonError(o.p)
+}
+
+func extractLineFromFormattedErrorMessage(formatted Object, n C.Py_ssize_t) string {
+	line := C.PyList_GetItem(formatted.p, n)
+	return C.GoString(C.PyUnicode_AsUTF8(line))
+}

--- a/error_py3_test.go
+++ b/error_py3_test.go
@@ -1,0 +1,7 @@
+// +build py3.4 py3.5 py3.6
+
+package py
+
+func loadExceptionModule() (ObjectModule, error) {
+	return LoadModule("builtins")
+}

--- a/error_test.go
+++ b/error_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestPyError(t *testing.T) {
-	Convey("When importing exceptions module and extract SyntaxError type", t, func() {
-		mdl, err := LoadModule("exceptions")
+	Convey("When importing builtins module and extract SyntaxError type", t, func() {
+		mdl, err := LoadModule("builtins")
 		So(err, ShouldBeNil)
 		So(mdl, ShouldNotBeNil)
 		Reset(func() {

--- a/error_test.go
+++ b/error_test.go
@@ -1,13 +1,14 @@
 package py
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestPyError(t *testing.T) {
 	Convey("When importing builtins module and extract SyntaxError type", t, func() {
-		mdl, err := LoadModule("builtins")
+		mdl, err := loadExceptionModule()
 		So(err, ShouldBeNil)
 		So(mdl, ShouldNotBeNil)
 		Reset(func() {

--- a/func_test.go
+++ b/func_test.go
@@ -105,7 +105,7 @@ func TestPyFunc(t *testing.T) {
 			Convey("it should return an error.", func() {
 				So(err, ShouldNotBeNil)
 				So(ret2.p, ShouldBeNil)
-				So(err.Error(), ShouldContainSubstring, "__call__() takes exactly 2 arguments (1 given)")
+				So(err.Error(), ShouldContainSubstring, "__call__() missing 1 required positional argument")
 			})
 		})
 

--- a/func_test.go
+++ b/func_test.go
@@ -1,10 +1,11 @@
 package py
 
 import (
+	"testing"
+
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/sensorbee/py.v0/mainthread"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
-	"testing"
 )
 
 func TestGetPyFuncError(t *testing.T) {
@@ -105,7 +106,8 @@ func TestPyFunc(t *testing.T) {
 			Convey("it should return an error.", func() {
 				So(err, ShouldNotBeNil)
 				So(ret2.p, ShouldBeNil)
-				So(err.Error(), ShouldContainSubstring, "__call__() missing 1 required positional argument")
+				So(err.Error(), ShouldContainSubstring, "TypeError:")
+				So(err.Error(), ShouldContainSubstring, "argument")
 			})
 		})
 

--- a/go2py_converter.go
+++ b/go2py_converter.go
@@ -9,54 +9,17 @@ PyObject* getPyNone() {
 */
 import "C"
 import (
-	"fmt"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"unsafe"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
+
+func getPyNone() *C.PyObject {
+	return C.getPyNone()
+}
 
 func getNewPyDic(m map[string]interface{}) Object {
 	return Object{}
-}
-
-func newPyObj(v data.Value) (Object, error) {
-	var pyobj *C.PyObject
-	var err error
-	switch v.Type() {
-	case data.TypeBool:
-		b, _ := data.ToInt(v)
-		pyobj = C.PyBool_FromLong(C.long(b))
-	case data.TypeInt:
-		i, _ := data.AsInt(v)
-		pyobj = C.PyLong_FromLong(C.long(i))
-	case data.TypeFloat:
-		f, _ := data.AsFloat(v)
-		pyobj = C.PyFloat_FromDouble(C.double(f))
-	case data.TypeString:
-		s, _ := data.AsString(v)
-		pyobj = newPyString(s)
-	case data.TypeBlob:
-		b, _ := data.AsBlob(v)
-		cb := (*C.char)(unsafe.Pointer(&b[0]))
-		pyobj = C.PyBytes_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
-	case data.TypeTimestamp:
-		t, _ := data.AsTimestamp(v)
-		pyobj = getPyDateTime(t)
-	case data.TypeArray:
-		innerArray, _ := data.AsArray(v)
-		pyobj, err = newPyArray(innerArray)
-	case data.TypeMap:
-		innerMap, _ := data.AsMap(v)
-		pyobj, err = newPyMap(innerMap)
-	case data.TypeNull:
-		pyobj = C.getPyNone()
-	default:
-		err = fmt.Errorf("unsupported type in sensorbee/py: %s", v.Type())
-	}
-
-	if pyobj == nil && err == nil {
-		return Object{}, getPyErr()
-	}
-	return Object{p: pyobj}, err
 }
 
 func newPyString(s string) *C.PyObject {

--- a/go2py_converter.go
+++ b/go2py_converter.go
@@ -27,7 +27,7 @@ func newPyObj(v data.Value) (Object, error) {
 		pyobj = C.PyBool_FromLong(C.long(b))
 	case data.TypeInt:
 		i, _ := data.AsInt(v)
-		pyobj = C.PyInt_FromLong(C.long(i))
+		pyobj = C.PyLong_FromLong(C.long(i))
 	case data.TypeFloat:
 		f, _ := data.AsFloat(v)
 		pyobj = C.PyFloat_FromDouble(C.double(f))
@@ -37,7 +37,7 @@ func newPyObj(v data.Value) (Object, error) {
 	case data.TypeBlob:
 		b, _ := data.AsBlob(v)
 		cb := (*C.char)(unsafe.Pointer(&b[0]))
-		pyobj = C.PyByteArray_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+		pyobj = C.PyBytes_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
 	case data.TypeTimestamp:
 		t, _ := data.AsTimestamp(v)
 		pyobj = getPyDateTime(t)
@@ -62,7 +62,7 @@ func newPyObj(v data.Value) (Object, error) {
 func newPyString(s string) *C.PyObject {
 	cs := C.CString(s)
 	defer C.free(unsafe.Pointer(cs))
-	return C.PyString_FromString(cs)
+	return C.PyUnicode_FromString(cs)
 }
 
 func newPyArray(a data.Array) (*C.PyObject, error) {

--- a/go2py_converter_py2.go
+++ b/go2py_converter_py2.go
@@ -1,0 +1,57 @@
+// +build !py3.4
+// +build !py3.5
+// +build !py3.6
+
+package py
+
+/*
+#include "Python.h"
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+)
+
+func newPyObj(v data.Value) (Object, error) {
+	var pyobj *C.PyObject
+	var err error
+	switch v.Type() {
+	case data.TypeBool:
+		b, _ := data.ToInt(v)
+		pyobj = C.PyBool_FromLong(C.long(b))
+	case data.TypeInt:
+		i, _ := data.AsInt(v)
+		pyobj = C.PyInt_FromLong(C.long(i))
+	case data.TypeFloat:
+		f, _ := data.AsFloat(v)
+		pyobj = C.PyFloat_FromDouble(C.double(f))
+	case data.TypeString:
+		s, _ := data.AsString(v)
+		pyobj = newPyString(s)
+	case data.TypeBlob:
+		b, _ := data.AsBlob(v)
+		cb := (*C.char)(unsafe.Pointer(&b[0]))
+		pyobj = C.PyByteArray_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+	case data.TypeTimestamp:
+		t, _ := data.AsTimestamp(v)
+		pyobj = getPyDateTime(t)
+	case data.TypeArray:
+		innerArray, _ := data.AsArray(v)
+		pyobj, err = newPyArray(innerArray)
+	case data.TypeMap:
+		innerMap, _ := data.AsMap(v)
+		pyobj, err = newPyMap(innerMap)
+	case data.TypeNull:
+		pyobj = getPyNone()
+	default:
+		err = fmt.Errorf("unsupported type in sensorbee/py: %s", v.Type())
+	}
+
+	if pyobj == nil && err == nil {
+		return Object{}, getPyErr()
+	}
+	return Object{p: pyobj}, err
+}

--- a/go2py_converter_py3.go
+++ b/go2py_converter_py3.go
@@ -1,0 +1,55 @@
+// +build py3.4 py3.5 py3.6
+
+package py
+
+/*
+#include "Python.h"
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+)
+
+func newPyObj(v data.Value) (Object, error) {
+	var pyobj *C.PyObject
+	var err error
+	switch v.Type() {
+	case data.TypeBool:
+		b, _ := data.ToInt(v)
+		pyobj = C.PyBool_FromLong(C.long(b))
+	case data.TypeInt:
+		i, _ := data.AsInt(v)
+		pyobj = C.PyLong_FromLong(C.long(i))
+	case data.TypeFloat:
+		f, _ := data.AsFloat(v)
+		pyobj = C.PyFloat_FromDouble(C.double(f))
+	case data.TypeString:
+		s, _ := data.AsString(v)
+		pyobj = newPyString(s)
+	case data.TypeBlob:
+		b, _ := data.AsBlob(v)
+		cb := (*C.char)(unsafe.Pointer(&b[0]))
+		pyobj = C.PyBytes_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+	case data.TypeTimestamp:
+		t, _ := data.AsTimestamp(v)
+		pyobj = getPyDateTime(t)
+	case data.TypeArray:
+		innerArray, _ := data.AsArray(v)
+		pyobj, err = newPyArray(innerArray)
+	case data.TypeMap:
+		innerMap, _ := data.AsMap(v)
+		pyobj, err = newPyMap(innerMap)
+	case data.TypeNull:
+		pyobj = getPyNone()
+	default:
+		err = fmt.Errorf("unsupported type in sensorbee/py: %s", v.Type())
+	}
+
+	if pyobj == nil && err == nil {
+		return Object{}, getPyErr()
+	}
+	return Object{p: pyobj}, err
+}

--- a/go2py_converter_test.go
+++ b/go2py_converter_test.go
@@ -27,7 +27,7 @@ func TestConvertGo2PyObject(t *testing.T) {
 				"string": argAndExpected{data.String("test"), "test"},
 				"int":    argAndExpected{data.Int(9), "9"},
 				"float":  argAndExpected{data.Float(0.9), "0.9"},
-				"byte":   argAndExpected{data.Blob([]byte("ABC")), "ABC"},
+				"byte":   argAndExpected{data.Blob([]byte("ABC")), "b'ABC'"},
 				"true":   argAndExpected{data.True, "True"},
 				"false":  argAndExpected{data.False, "False"},
 				"null":   argAndExpected{data.Null{}, "None"},

--- a/go2py_converter_test.go
+++ b/go2py_converter_test.go
@@ -2,11 +2,12 @@ package py
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/sensorbee/py.v0/mainthread"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
-	"testing"
-	"time"
 )
 
 func TestConvertGo2PyObject(t *testing.T) {
@@ -17,17 +18,15 @@ func TestConvertGo2PyObject(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(mdl, ShouldNotBeNil)
 
-		type argAndExpected struct {
-			arg      data.Value
-			expected string
-		}
-
 		Convey("When set an object", func() {
+			type argAndExpected struct {
+				arg      data.Value
+				expected string
+			}
 			values := map[string]argAndExpected{
 				"string": argAndExpected{data.String("test"), "test"},
 				"int":    argAndExpected{data.Int(9), "9"},
 				"float":  argAndExpected{data.Float(0.9), "0.9"},
-				"byte":   argAndExpected{data.Blob([]byte("ABC")), "b'ABC'"},
 				"true":   argAndExpected{data.True, "True"},
 				"false":  argAndExpected{data.False, "False"},
 				"null":   argAndExpected{data.Null{}, "None"},
@@ -41,9 +40,11 @@ func TestConvertGo2PyObject(t *testing.T) {
 					So(actual, ShouldEqual, v.expected)
 				})
 			}
+		})
 
-			Convey("Then function should return string value: time", func() {
-				now := time.Now().UTC()
+		Convey("When set a time value", func() {
+			now := time.Now().UTC()
+			Convey("Then function should return time as string type", func() {
 				actual, err := mdl.Call("go2py_tostr", data.Timestamp(now))
 				So(err, ShouldBeNil)
 				retStr, err := data.AsString(actual)
@@ -51,6 +52,15 @@ func TestConvertGo2PyObject(t *testing.T) {
 				parsed, err := time.Parse("2006-01-02 15:04:05.999999999", retStr)
 				So(err, ShouldBeNil)
 				So(parsed, ShouldResemble, now.Truncate(time.Microsecond)) // Python's datetime has microseconds precision
+			})
+		})
+
+		Convey("When set a byte array", func() {
+			b := data.Blob([]byte("ABC"))
+			Convey("Then function should return string", func() {
+				actual, err := mdl.Call("go2py_toutf8", b)
+				So(err, ShouldBeNil)
+				So(actual, ShouldEqual, "ABC")
 			})
 		})
 

--- a/mainthread/cgolinks.go
+++ b/mainthread/cgolinks.go
@@ -1,0 +1,10 @@
+// !py3.4
+// !py3.5
+// !py3.6
+
+package mainthread
+
+/*
+#cgo pkg-config: python-2.7
+*/
+import "C"

--- a/mainthread/cgolinks.go
+++ b/mainthread/cgolinks.go
@@ -1,6 +1,6 @@
-// !py3.4
-// !py3.5
-// !py3.6
+// +build !py3.4
+// +build !py3.5
+// +build !py3.6
 
 package mainthread
 

--- a/mainthread/cgolinks_py3.4.go
+++ b/mainthread/cgolinks_py3.4.go
@@ -1,0 +1,8 @@
+// +build py3.4
+
+package mainthread
+
+/*
+#cgo pkg-config: python-3.4
+*/
+import "C"

--- a/mainthread/cgolinks_py3.5.go
+++ b/mainthread/cgolinks_py3.5.go
@@ -1,0 +1,8 @@
+// +build py3.5
+
+package mainthread
+
+/*
+#cgo pkg-config: python-3.5
+*/
+import "C"

--- a/mainthread/cgolinks_py3.6.go
+++ b/mainthread/cgolinks_py3.6.go
@@ -1,0 +1,8 @@
+// +build py3.6
+
+package mainthread
+
+/*
+#cgo pkg-config: python-3.6
+*/
+import "C"

--- a/mainthread/init.go
+++ b/mainthread/init.go
@@ -10,7 +10,6 @@ this package is executed before all other init functions in py package.
 package mainthread
 
 /*
-#cgo pkg-config: python-3.5
 #include "Python.h"
 */
 import "C"

--- a/mainthread/init.go
+++ b/mainthread/init.go
@@ -10,7 +10,7 @@ this package is executed before all other init functions in py package.
 package mainthread
 
 /*
-#cgo pkg-config: python-2.7
+#cgo pkg-config: python-3.5
 #include "Python.h"
 */
 import "C"

--- a/module_test.go
+++ b/module_test.go
@@ -1,10 +1,11 @@
 package py
 
 import (
+	"testing"
+
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/sensorbee/py.v0/mainthread"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
-	"testing"
 )
 
 func TestLoadModuleError(t *testing.T) {
@@ -177,7 +178,7 @@ func TestNewInstanceAndStateness(t *testing.T) {
 				ins := &ObjectInstance{obj}
 				actual, err := ins.Call("confirm")
 				So(err, ShouldBeNil)
-				So(actual, ShouldEqual, "55_5_{'v1': 'homhom'}")
+				So(actual, ShouldEqual, "55_5_homhom")
 			})
 		})
 
@@ -249,7 +250,7 @@ func TestNewInstanceWithKeywordArgument(t *testing.T) {
 
 				actual, err := ins.Call("confirm_init")
 				So(err, ShouldBeNil)
-				So(actual, ShouldBeIn, []string{"1_2_{'c': 3, 'd': 4}", "1_2_{'d': 4, 'c': 3}"})
+				So(actual, ShouldEqual, "1_2_3_4_")
 			})
 		})
 
@@ -268,14 +269,14 @@ func TestNewInstanceWithKeywordArgument(t *testing.T) {
 
 				actual, err := ins.Call("confirm_init")
 				So(err, ShouldBeNil)
-				So(actual, ShouldEqual, "1_5_{}")
+				So(actual, ShouldEqual, "1_5___")
 			})
 		})
 
 		Convey("When get a new test python instance with named and non-named arguments mixed", func() {
 			arg := data.Int(1)
 			kwdArg := data.Map{
-				"v1": data.String("homhom"),
+				"e": data.String("homhom"),
 			}
 			ins, err := mdl.NewInstance("PythonTestForKwd", []data.Value{arg}, kwdArg)
 			Reset(func() {
@@ -288,7 +289,7 @@ func TestNewInstanceWithKeywordArgument(t *testing.T) {
 
 				actual, err := ins.Call("confirm_init")
 				So(err, ShouldBeNil)
-				So(actual, ShouldEqual, "1_5_{'v1': 'homhom'}")
+				So(actual, ShouldEqual, "1_5___homhom")
 			})
 		})
 

--- a/module_test.go
+++ b/module_test.go
@@ -249,7 +249,7 @@ func TestNewInstanceWithKeywordArgument(t *testing.T) {
 
 				actual, err := ins.Call("confirm_init")
 				So(err, ShouldBeNil)
-				So(actual, ShouldEqual, "1_2_{'c': 3, 'd': 4}")
+				So(actual, ShouldBeIn, []string{"1_2_{'c': 3, 'd': 4}", "1_2_{'d': 4, 'c': 3}"})
 			})
 		})
 

--- a/py2go_converter.go
+++ b/py2go_converter.go
@@ -4,129 +4,20 @@ package py
 #include "Python.h"
 #include "datetime.h"
 
-int IsPyTypeTrue(PyObject *o) {
-  return o == Py_True;
-}
-
-int IsPyTypeFalse(PyObject *o) {
-  return o == Py_False;
-}
-
-int IsPyTypeLong(PyObject *o) {
-  return PyLong_CheckExact(o);
-}
-
-int IsPyTypeFloat(PyObject *o) {
-  return PyFloat_CheckExact(o);
-}
-
-int IsPyTypeByteArray(PyObject *o) {
-  return PyByteArray_CheckExact(o);
-}
-
-int IsPyTypeBytes(PyObject *o) {
-  return PyBytes_CheckExact(o);
-}
-
-int IsPyTypeList(PyObject *o) {
-  return PyList_CheckExact(o);
-}
-
-int IsPyTypeDict(PyObject *o) {
-  return PyDict_CheckExact(o);
-}
-
-int IsPyTypeTuple(PyObject *o) {
-  return PyTuple_CheckExact(o);
-}
-
-int IsPyTypeNone(PyObject *o) {
-  return o == Py_None;
-}
-
 int IsPyTypeUnicode(PyObject *o) {
   return PyUnicode_CheckExact(o);
-}
-
-PyTypeObject* GetTypeObject(PyObject *o) {
-  return (PyTypeObject*)PyObject_Type(o);
-}
-
-const char* GetTypeName(PyTypeObject *t) {
-  return t->tp_name;
-}
-
-void DecRefTypeObject(PyTypeObject *t) {
-  Py_DECREF(t);
 }
 */
 import "C"
 import (
-	"fmt"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"time"
 	"unsafe"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
-func fromPyTypeObject(o *C.PyObject) (data.Value, error) {
-	switch {
-	case C.IsPyTypeTrue(o) > 0:
-		return data.Bool(true), nil
-
-	case C.IsPyTypeFalse(o) > 0:
-		return data.Bool(false), nil
-
-	case C.IsPyTypeLong(o) > 0:
-		return data.Int(C.PyLong_AsLong(o)), nil
-
-	case C.IsPyTypeFloat(o) > 0:
-		return data.Float(C.PyFloat_AsDouble(o)), nil
-
-	case C.IsPyTypeByteArray(o) > 0:
-		bytePtr := C.PyByteArray_FromObject(o)
-		charPtr := C.PyByteArray_AsString(bytePtr)
-		size := C.int(C.PyByteArray_Size(o))
-		return data.Blob(C.GoBytes(unsafe.Pointer(charPtr), size)), nil
-
-	case C.IsPyTypeBytes(o) > 0:
-		charPtr := C.PyBytes_AsString(o)
-		size := C.int(C.PyBytes_Size(o))
-		return data.Blob(C.GoBytes(unsafe.Pointer(charPtr), size)), nil
-
-	case C.IsPyTypeUnicode(o) > 0:
-		// Use unicode string as UTF-8 in py because
-		// Go's source code is defined to be UTF-8 text and string literal is too.
-		var size C.Py_ssize_t
-		charPtr := C.PyUnicode_AsUTF8AndSize(o, &size)
-		if charPtr == nil {
-			return data.Null{}, getPyErr()
-		}
-		return data.String(string(C.GoBytes(unsafe.Pointer(charPtr), C.int(size)))), nil
-
-	case isPyTypeDateTime(o):
-		return fromTimestamp(o), nil
-
-	case C.IsPyTypeList(o) > 0:
-		return fromPyArray(o)
-
-	case C.IsPyTypeDict(o) > 0:
-		return fromPyMap(o)
-
-	case C.IsPyTypeTuple(o) > 0:
-		return fromPyTuple(o)
-
-	case C.IsPyTypeNone(o) > 0:
-		return data.Null{}, nil
-
-	}
-
-	t := C.GetTypeObject(o)
-	if t == nil {
-		return data.Null{}, fmt.Errorf("unsupported type in sensorbee/py (cannot detect python object type)")
-	}
-	tn := C.GoString(C.GetTypeName(t))
-	defer C.DecRefTypeObject(t)
-	return data.Null{}, fmt.Errorf("unsupported type in sensorbee/py: %v", tn)
+func isPyTypeUnicode(o *C.PyObject) int {
+	return int(C.IsPyTypeUnicode(o))
 }
 
 func fromPyArray(ls *C.PyObject) (data.Array, error) {
@@ -151,7 +42,7 @@ func fromPyMap(o *C.PyObject) (data.Map, error) {
 
 	for C.int(C.PyDict_Next(o, &pos, &key, &value)) > 0 {
 		// data.Map's key is only allowed string or unicode
-		if C.IsPyTypeBytes(key) == 0 && C.IsPyTypeUnicode(key) == 0 {
+		if isPyTypeString(key) == 0 && isPyTypeUnicode(key) == 0 {
 			continue
 		}
 		k, _ := fromPyTypeObject(key)

--- a/py2go_converter_py2.go
+++ b/py2go_converter_py2.go
@@ -1,0 +1,138 @@
+// +build !py3.4
+// +build !py3.5
+// +build !py3.6
+
+package py
+
+/*
+#include "Python.h"
+
+int IsPyTypeTrue(PyObject *o) {
+  return o == Py_True;
+}
+
+int IsPyTypeFalse(PyObject *o) {
+  return o == Py_False;
+}
+
+int IsPyTypeInt(PyObject *o) {
+  return PyInt_CheckExact(o);
+}
+
+int IsPyTypeFloat(PyObject *o) {
+  return PyFloat_CheckExact(o);
+}
+
+int IsPyTypeByteArray(PyObject *o) {
+  return PyByteArray_CheckExact(o);
+}
+
+int IsPyTypeString(PyObject *o) {
+  return PyString_CheckExact(o);
+}
+
+int IsPyTypeList(PyObject *o) {
+  return PyList_CheckExact(o);
+}
+
+int IsPyTypeDict(PyObject *o) {
+  return PyDict_CheckExact(o);
+}
+
+int IsPyTypeTuple(PyObject *o) {
+  return PyTuple_CheckExact(o);
+}
+
+int IsPyTypeNone(PyObject *o) {
+  return o == Py_None;
+}
+
+PyTypeObject* GetTypeObject(PyObject *o) {
+  return (PyTypeObject*)PyObject_Type(o);
+}
+
+const char* GetTypeName(PyTypeObject *t) {
+  return t->tp_name;
+}
+
+void DecRefTypeObject(PyTypeObject *t) {
+  Py_DECREF(t);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+)
+
+func fromPyTypeObject(o *C.PyObject) (data.Value, error) {
+	switch {
+	case C.IsPyTypeTrue(o) > 0:
+		return data.Bool(true), nil
+
+	case C.IsPyTypeFalse(o) > 0:
+		return data.Bool(false), nil
+
+	case C.IsPyTypeInt(o) > 0:
+		return data.Int(C.PyInt_AsLong(o)), nil
+
+	case C.IsPyTypeFloat(o) > 0:
+		return data.Float(C.PyFloat_AsDouble(o)), nil
+
+	case C.IsPyTypeByteArray(o) > 0:
+		bytePtr := C.PyByteArray_FromObject(o)
+		charPtr := C.PyByteArray_AsString(bytePtr)
+		l := C.PyByteArray_Size(o)
+		return data.Blob(C.GoBytes(unsafe.Pointer(charPtr), C.int(l))), nil
+
+	case C.IsPyTypeString(o) > 0:
+		size := C.int(C.PyString_Size(o))
+		charPtr := C.PyString_AsString(o)
+		return data.String(string(C.GoBytes(unsafe.Pointer(charPtr), size))), nil
+
+	case isPyTypeUnicode(o) > 0:
+		// Use unicode string as UTF-8 in py because
+		// Go's source code is defined to be UTF-8 text and string literal is too.
+		utf8 := C.CString("UTF-8")
+		defer C.free(unsafe.Pointer(utf8))
+
+		strObj := C.PyUnicode_AsEncodedString(o, utf8, nil)
+		if strObj == nil {
+			return data.Null{}, getPyErr()
+		}
+		str := Object{p: strObj}
+		defer str.decRef()
+
+		return fromPyTypeObject(str.p)
+
+	case isPyTypeDateTime(o):
+		return fromTimestamp(o), nil
+
+	case C.IsPyTypeList(o) > 0:
+		return fromPyArray(o)
+
+	case C.IsPyTypeDict(o) > 0:
+		return fromPyMap(o)
+
+	case C.IsPyTypeTuple(o) > 0:
+		return fromPyTuple(o)
+
+	case C.IsPyTypeNone(o) > 0:
+		return data.Null{}, nil
+
+	}
+
+	t := C.GetTypeObject(o)
+	if t == nil {
+		return data.Null{}, fmt.Errorf("unsupported type in sensorbee/py (cannot detect python object type)")
+	}
+	tn := C.GoString(C.GetTypeName(t))
+	defer C.DecRefTypeObject(t)
+	return data.Null{}, fmt.Errorf("unsupported type in sensorbee/py: %v", tn)
+}
+
+func isPyTypeString(o *C.PyObject) int {
+	return int(C.IsPyTypeString(o))
+}

--- a/py2go_converter_py3.go
+++ b/py2go_converter_py3.go
@@ -1,0 +1,131 @@
+// +build py3.4 py3.5 py3.6
+
+package py
+
+/*
+#include "Python.h"
+
+int IsPyTypeTrue(PyObject *o) {
+  return o == Py_True;
+}
+
+int IsPyTypeFalse(PyObject *o) {
+  return o == Py_False;
+}
+
+int IsPyTypeLong(PyObject *o) {
+  return PyLong_CheckExact(o);
+}
+
+int IsPyTypeFloat(PyObject *o) {
+  return PyFloat_CheckExact(o);
+}
+
+int IsPyTypeByteArray(PyObject *o) {
+  return PyByteArray_CheckExact(o);
+}
+
+int IsPyTypeBytes(PyObject *o) {
+  return PyBytes_CheckExact(o);
+}
+
+int IsPyTypeList(PyObject *o) {
+  return PyList_CheckExact(o);
+}
+
+int IsPyTypeDict(PyObject *o) {
+  return PyDict_CheckExact(o);
+}
+
+int IsPyTypeTuple(PyObject *o) {
+  return PyTuple_CheckExact(o);
+}
+
+int IsPyTypeNone(PyObject *o) {
+  return o == Py_None;
+}
+
+PyTypeObject* GetTypeObject(PyObject *o) {
+  return (PyTypeObject*)PyObject_Type(o);
+}
+
+const char* GetTypeName(PyTypeObject *t) {
+  return t->tp_name;
+}
+
+void DecRefTypeObject(PyTypeObject *t) {
+  Py_DECREF(t);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+)
+
+func fromPyTypeObject(o *C.PyObject) (data.Value, error) {
+	switch {
+	case C.IsPyTypeTrue(o) > 0:
+		return data.Bool(true), nil
+
+	case C.IsPyTypeFalse(o) > 0:
+		return data.Bool(false), nil
+
+	case C.IsPyTypeLong(o) > 0:
+		return data.Int(C.PyLong_AsLong(o)), nil
+
+	case C.IsPyTypeFloat(o) > 0:
+		return data.Float(C.PyFloat_AsDouble(o)), nil
+
+	case C.IsPyTypeByteArray(o) > 0:
+		bytePtr := C.PyByteArray_FromObject(o)
+		charPtr := C.PyByteArray_AsString(bytePtr)
+		size := C.int(C.PyByteArray_Size(o))
+		return data.Blob(C.GoBytes(unsafe.Pointer(charPtr), size)), nil
+
+	case C.IsPyTypeBytes(o) > 0:
+		charPtr := C.PyBytes_AsString(o)
+		size := C.int(C.PyBytes_Size(o))
+		return data.Blob(C.GoBytes(unsafe.Pointer(charPtr), size)), nil
+
+	case isPyTypeUnicode(o) > 0:
+		// Use unicode string as UTF-8 in py because
+		// Go's source code is defined to be UTF-8 text and string literal is too.
+		var size C.Py_ssize_t
+		charPtr := C.PyUnicode_AsUTF8AndSize(o, &size)
+		if charPtr == nil {
+			return data.Null{}, getPyErr()
+		}
+		return data.String(string(C.GoBytes(unsafe.Pointer(charPtr), C.int(size)))), nil
+
+	case isPyTypeDateTime(o):
+		return fromTimestamp(o), nil
+
+	case C.IsPyTypeList(o) > 0:
+		return fromPyArray(o)
+
+	case C.IsPyTypeDict(o) > 0:
+		return fromPyMap(o)
+
+	case C.IsPyTypeTuple(o) > 0:
+		return fromPyTuple(o)
+
+	case C.IsPyTypeNone(o) > 0:
+		return data.Null{}, nil
+
+	}
+
+	t := C.GetTypeObject(o)
+	if t == nil {
+		return data.Null{}, fmt.Errorf("unsupported type in sensorbee/py (cannot detect python object type)")
+	}
+	tn := C.GoString(C.GetTypeName(t))
+	defer C.DecRefTypeObject(t)
+	return data.Null{}, fmt.Errorf("unsupported type in sensorbee/py: %v", tn)
+}
+
+func isPyTypeString(o *C.PyObject) int {
+	return int(C.IsPyTypeBytes(o))
+}

--- a/pystate/_test_creator_module.py
+++ b/pystate/_test_creator_module.py
@@ -51,7 +51,7 @@ class TestClass4(object):
 
     @staticmethod
     def load(filepath, *args, **kwargs):
-        with open(filepath, 'r') as f:
+        with open(filepath, 'rb') as f:
             return six.moves.cPickle.load(f)
 
     def modify_params(self):
@@ -62,7 +62,7 @@ class TestClass4(object):
         return self.params
 
     def save(self, filepath, *args, **kwargs):
-        with open(filepath, 'w') as f:
+        with open(filepath, 'wb') as f:
             six.moves.cPickle.dump(self, f)
 
 


### PR DESCRIPTION
* on default, py plugin build with python2.7
* using build constraints `--tags` , py plugin can be built with python3.x
    * support python3.4, 3.5, 3.6
    * using build constraints may not be a best way to support both python2 and python3, and it is possible to change this strategy in future
* very thanks! @nejigane -san

need to add CI test using python3, will update later