### PR TITLE
Fix index out of range error when set empty blob

### DIFF
--- a/go2py_converter_py2.go
+++ b/go2py_converter_py2.go
@@ -33,8 +33,12 @@ func newPyObj(v data.Value) (Object, error) {
 		pyobj = newPyString(s)
 	case data.TypeBlob:
 		b, _ := data.AsBlob(v)
-		cb := (*C.char)(unsafe.Pointer(&b[0]))
-		pyobj = C.PyByteArray_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+		if len(b) == 0 {
+			pyobj = C.PyByteArray_FromStringAndSize(nil, 0)
+		} else {
+			cb := (*C.char)(unsafe.Pointer(&b[0]))
+			pyobj = C.PyByteArray_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+		}
 	case data.TypeTimestamp:
 		t, _ := data.AsTimestamp(v)
 		pyobj = getPyDateTime(t)

--- a/go2py_converter_py3.go
+++ b/go2py_converter_py3.go
@@ -31,8 +31,12 @@ func newPyObj(v data.Value) (Object, error) {
 		pyobj = newPyString(s)
 	case data.TypeBlob:
 		b, _ := data.AsBlob(v)
-		cb := (*C.char)(unsafe.Pointer(&b[0]))
-		pyobj = C.PyBytes_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+		if len(b) == 0 {
+			pyobj = C.PyBytes_FromStringAndSize(nil, 0)
+		} else {
+			cb := (*C.char)(unsafe.Pointer(&b[0]))
+			pyobj = C.PyBytes_FromStringAndSize(cb, C.Py_ssize_t(len(b)))
+		}
 	case data.TypeTimestamp:
 		t, _ := data.AsTimestamp(v)
 		pyobj = getPyDateTime(t)

--- a/go2py_converter_test.go
+++ b/go2py_converter_test.go
@@ -64,6 +64,15 @@ func TestConvertGo2PyObject(t *testing.T) {
 			})
 		})
 
+		Convey("When set a empty byte array", func() {
+			b := data.Blob([]byte(""))
+			Convey("Then function should return empty string", func() {
+				actual, err := mdl.Call("go2py_toutf8", b)
+				So(err, ShouldBeNil)
+				So(actual, ShouldEqual, "")
+			})
+		})
+
 		Convey("When set map in map and map in array", func() {
 			arg := data.Map{
 				"string": data.String("test"),


### PR DESCRIPTION
pystate output the following error when use empty blob data:

```
cannot call 'xxxx' due to panic: runtime error: index out of range
```

This patch will fix this problem.

My test code is followings:

* Python:
```python
class Foo():
    @classmethod
    def create(cls):
        return cls()

    def showmsg(self, msg):
        print(" *** {0} ***".format(msg))
```

* BQL:
```sql
CREATE STATE p TYPE pystate
  WITH module_name="foo",
       class_name="Foo";

EVAL pystate_func("p", "showmsg", ""::blob);
```