### PR TITLE
Update CI config, remove too old golang version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: go
 
 matrix:
   include:
-    - go: 1.8.x
+    - go: 1.11.x
       env:
         - PYTHON_VERSION=2.7
-    - go: 1.8.x
+    - go: 1.11.x
       env:
         - CHECK_GOLINT=true
         - PYTHON_VERSION=3.4  # Ubuntu14's python3 = 3.4.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ script:
     fi
 
 after_success:
-  - if [ $GOCOVERAGE ]; then goveralls -coverprofile=.profile.cov -repotoken $COVERALLS_TOKEN; fi
+  - if [ $GOCOVERAGE ]; then goveralls -coverprofile=.profile.cov -repotoken=$COVERALLS_TOKEN; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: go
 
 matrix:
   include:
-    - go: 1.11.x
+    - go: 1.9
       env:
         - PYTHON_VERSION=2.7
-    - go: 1.11.x
+    - go: 1.9
       env:
-        - CHECK_GOLINT=true
+        - CHECK_GOLINT=false  # tentatively off, golint not support go1.9
         - PYTHON_VERSION=3.4  # Ubuntu14's python3 = 3.4.x
 
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,13 @@ language: go
 
 matrix:
   include:
-    - go: 1.4.3
+    - go: 1.8.x
       env:
         - PYTHON_VERSION=2.7
-    - go: 1.5.4
-      env:
-        - PYTHON_VERSION=2.7
-    - go: 1.6.4
+    - go: 1.8.x
       env:
         - CHECK_GOLINT=true
-        - PYTHON_VERSION=2.7
-    - go: 1.7.4
-      env:
-        - CHECK_GOLINT=true
-        - PYTHON_VERSION=2.7
-    - go: 1.7.4
-      env:
-        - CHECK_GOLINT=true
-        - PYTHON_VERSION=3.4
+        - PYTHON_VERSION=3.4  # Ubuntu14's python3 = 3.4.x
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       env:
         - CHECK_GOLINT=false  # tentatively off, golint not support go1.9
         - PYTHON_VERSION=3.4  # Ubuntu14's python3 = 3.4.x
+        - GOCOVERAGE=true
 
 sudo: required
 dist: trusty
@@ -56,4 +57,4 @@ script:
     fi
 
 after_success:
-  - if [ "$TRAVIS_GO_VERSION" = "1.7.4" ]; then goveralls -coverprofile=.profile.cov -repotoken $COVERALLS_TOKEN; fi
+  - if [ $GOCOVERAGE ]; then goveralls -coverprofile=.profile.cov -repotoken $COVERALLS_TOKEN; fi

--- a/module_test.go
+++ b/module_test.go
@@ -16,7 +16,8 @@ func TestLoadModuleError(t *testing.T) {
 			_, err := LoadModule("not_exist_module")
 			Convey("Then an error should be occurred", func() {
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "ImportError")
+				// Python2.7,<=3.5: ImportError, >=3.6: ModuleNotFoundError
+				So(err.Error(), ShouldContainSubstring, "Error")
 			})
 		})
 


### PR DESCRIPTION
~use go1.8, because supported by sensorbee~ 
~to run golint, update to latest version~

I found it's hard to fix sensorbee upgrading for go1.11 soon, so tentatively use go1.9 on this plugin and off lint.